### PR TITLE
Add Capacitor setup for Android APK builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # dirscrapping
- Generador de direcciones aleatorias
+Generador de direcciones aleatorias
 /public/index.html
+
+## Ejecutar el proyecto en la web
+
+```bash
+npm install
+npm start
+```
+
+La aplicación quedará disponible en `http://localhost:3000`.
+
+## Crear un APK de Android con Capacitor
+
+1. Instala las dependencias necesarias (esto actualizará el `package-lock.json`):
+
+   ```bash
+   npm install
+   npm install @capacitor/core @capacitor/android
+   npm install -D @capacitor/cli
+   ```
+
+2. Inicializa la plataforma de Android dentro del proyecto:
+
+   ```bash
+   npx cap add android
+   ```
+
+   Esto generará la carpeta `android/` con un proyecto de Android Studio listo para compilar.
+
+3. Copia los archivos web a la plataforma nativa cuando hagas cambios:
+
+   ```bash
+   npm run sync:android
+   ```
+
+4. Abre el proyecto nativo para compilar el APK:
+
+   ```bash
+   npx cap open android
+   ```
+
+5. Desde Android Studio ejecuta **Build > Build Bundle(s) / APK(s) > Build APK(s)** para generar el archivo `.apk` de depuración. El APK quedará disponible en `android/app/build/outputs/apk/debug/`.
+
+### Requisitos adicionales
+
+- Android Studio 2022.1 o superior con el SDK de Android 13 o más reciente.
+- Java 17 y Gradle Wrapper (se configura automáticamente al abrir el proyecto con Android Studio).
+- Un dispositivo o emulador con Android 6.0 (API 23) o superior para las pruebas.

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,9 @@
+{
+  "appId": "com.dirscrapping.generator",
+  "appName": "Generador de Direcciones",
+  "webDir": "public",
+  "bundledWebRuntime": false,
+  "server": {
+    "androidScheme": "https"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "sync:android": "npx cap sync android"
   },
   "keywords": [
     "random",
@@ -15,6 +16,13 @@
   ],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "@capacitor/android": "^6.1.2",
+    "@capacitor/core": "^6.1.2"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^6.1.2"
+  },
   "engines": {
     "node": ">=18.0.0"
   }


### PR DESCRIPTION
## Summary
- add Capacitor configuration that points the app to the `public` web assets
- declare Capacitor dependencies and helper script to sync Android assets
- document the workflow for generating an Android APK with Capacitor

## Testing
- npm install @capacitor/core @capacitor/android --save *(fails: npm registry access is blocked in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68de20b1bc78832796a8f8a124d0fd3b