### PR TITLE
Refactor app to run entirely in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # dirscrapping
- Generador de direcciones aleatorias
+Generador de direcciones aleatorias
 /public/index.html
+
+## Ejecutar el proyecto en la web
+
+La aplicación es completamente estática, por lo que no necesitas un servidor de Node.js.
+
+- Abre directamente `public/index.html` en tu navegador, o bien
+- Sirve la carpeta `public` con tu herramienta favorita (por ejemplo `npx http-server public` o `python -m http.server`).
+
+## Crear un APK de Android con Capacitor
+
+1. Instala las dependencias necesarias (esto actualizará el `package-lock.json`):
+
+   ```bash
+   npm install
+   npm install @capacitor/core @capacitor/android
+   npm install -D @capacitor/cli
+   ```
+
+2. Inicializa la plataforma de Android dentro del proyecto:
+
+   ```bash
+   npx cap add android
+   ```
+
+   Esto generará la carpeta `android/` con un proyecto de Android Studio listo para compilar.
+
+3. Copia los archivos web a la plataforma nativa cuando hagas cambios:
+
+   ```bash
+   npm run sync:android
+   ```
+
+4. Abre el proyecto nativo para compilar el APK:
+
+   ```bash
+   npx cap open android
+   ```
+
+5. Desde Android Studio ejecuta **Build > Build Bundle(s) / APK(s) > Build APK(s)** para generar el archivo `.apk` de depuración. El APK quedará disponible en `android/app/build/outputs/apk/debug/`.
+
+### Requisitos adicionales
+
+- Android Studio 2022.1 o superior con el SDK de Android 13 o más reciente.
+- Java 17 y Gradle Wrapper (se configura automáticamente al abrir el proyecto con Android Studio).
+- Un dispositivo o emulador con Android 6.0 (API 23) o superior para las pruebas.

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,9 @@
+{
+  "appId": "com.dirscrapping.generator",
+  "appName": "Generador de Direcciones",
+  "webDir": "public",
+  "bundledWebRuntime": false,
+  "server": {
+    "androidScheme": "https"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "2.0.0",
   "description": "Generador de direcciones aleatorias con interfaz moderna",
   "type": "module",
-  "main": "server.js",
+  "main": "public/index.html",
   "scripts": {
-    "start": "node server.js",
-    "dev": "node --watch server.js"
+    "start": "node -e \"console.log('Esta aplicación es estática. Abre public/index.html en tu navegador o sirve la carpeta public con tu herramienta favorita.');\"",
+    "dev": "npm run start",
+    "sync:android": "npx cap sync android"
   },
   "keywords": [
     "random",
@@ -15,6 +16,13 @@
   ],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "@capacitor/android": "^6.1.2",
+    "@capacitor/core": "^6.1.2"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^6.1.2"
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -209,6 +209,6 @@
         </div>
     </div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,5 @@
+import { fetchAddress } from '../server.js';
+
 // Función para alternar el modo oscuro
 function toggleDarkMode() {
     const body = document.body;
@@ -37,13 +39,7 @@ async function generateNewAddress() {
     loading.classList.add('active');
     
     try {
-        const response = await fetch(`/generate-address?country=${selectedCountry}`);
-        
-        if (!response.ok) {
-            throw new Error('Error al generar dirección');
-        }
-        
-        const data = await response.json();
+        const data = await fetchAddress(selectedCountry);
         
         // Pequeño delay para efecto visual
         setTimeout(() => {
@@ -147,3 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
         value.style.transition = 'opacity 0.3s ease';
     });
 });
+
+// Exponer funciones utilizadas en los atributos HTML
+window.generateNewAddress = generateNewAddress;
+window.copyToClipboard = copyToClipboard;


### PR DESCRIPTION
## Summary
- replace the Node.js HTTP server with a browser-friendly module that still encapsulates the postal code mapping and address-fetching logic
- update the front-end script to import the new module, expose the helpers required by inline handlers, and load it via an ES module script tag
- refresh package metadata and documentation to describe the static workflow now that the app runs without a Node server

## Testing
- npm run start *(prints guidance for serving the static site)*

------
https://chatgpt.com/codex/tasks/task_e_68de20b1bc78832796a8f8a124d0fd3b