### PR TITLE
Add Capacitor tooling to package web app as Android APK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+android/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# Generador de Direcciones - Empaquetado Android
+
+Este proyecto transforma la app web ubicada en `public/` en un APK de Android utilizando [Ionic Capacitor](https://capacitorjs.com/). Se añadió una configuración mínima para que puedas construir la app híbrida directamente desde esta carpeta.
+
+## Requisitos previos
+
+Instala las herramientas necesarias:
+
+- [Node.js 18+](https://nodejs.org/)
+- [Android Studio](https://developer.android.com/studio)
+  - Incluye el SDK de Android, `adb` y las herramientas de línea de comando.
+- Java 17 (Android Studio lo instala automáticamente)
+- Un dispositivo o emulador Android para las pruebas.
+
+## Pasos para generar el APK
+
+1. **Instalar dependencias**
+
+   ```bash
+   npm install
+   ```
+
+2. **Generar los archivos web de producción**
+
+   ```bash
+   npm run build
+   ```
+
+   El script copia todo lo que está en `public/` a la carpeta `dist/`, que es la que Capacitor usa como paquete web.
+
+3. **Sincronizar el proyecto Android**
+
+   ```bash
+   npm run prepare:android
+   ```
+
+   Este comando ejecuta `npx cap sync android`, creando (o actualizando) el proyecto Android dentro de la carpeta `android/`.
+
+4. **Abrir Android Studio** (opcional pero recomendado)
+
+   ```bash
+   npm run open:android
+   ```
+
+   Desde Android Studio puedes compilar y generar el APK o App Bundle (`Build > Build Bundle(s) / APK(s) > Build APK(s)`).
+
+5. **Compilación por línea de comando**
+
+   Si prefieres compilar sin abrir Android Studio, ejecuta:
+
+   ```bash
+   cd android
+   ./gradlew assembleDebug
+   ```
+
+   El APK se generará en `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+## Limpieza
+
+Para eliminar las carpetas generadas (`dist/` y `android/`):
+
+```bash
+npm run clean
+```
+
+## Personalización de la app
+
+- Cambia el identificador del paquete (`appId`) en `capacitor.config.ts` si necesitas subir la app a Google Play.
+- Los recursos web (HTML, CSS y JS) siguen viviendo en `public/`. Modifica esos archivos y vuelve a ejecutar `npm run build` para refrescar la app nativa.
+
+## Nota sobre permisos
+
+La app es puramente estática y no requiere permisos especiales. Si en el futuro necesitas acceso a funcionalidades nativas, puedes añadir plugins de Capacitor y ejecutar nuevamente `npm run prepare:android`.

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,13 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.dirscrapping.app',
+  appName: 'Generador de Direcciones',
+  webDir: 'dist',
+  bundledWebRuntime: false,
+  server: {
+    androidScheme: 'https'
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dirscrapping",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Generador de direcciones empaquetado como app Android con Capacitor",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "clean": "node scripts/clean.js",
+    "prepare:android": "npm run build && npx cap sync android",
+    "open:android": "npx cap open android"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "5.7.4"
+  },
+  "dependencies": {
+    "@capacitor/core": "5.7.4"
+  },
+  "type": "module"
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,14 @@
+import { cpSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = join(process.cwd(), 'public');
+const dest = join(process.cwd(), 'dist');
+
+if (!existsSync(src)) {
+  console.error('No se encontró el directorio "public" para construir la app web.');
+  process.exit(1);
+}
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });
+console.log('Archivos copiados a dist/');

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,6 @@
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+rmSync(join(process.cwd(), 'dist'), { recursive: true, force: true });
+rmSync(join(process.cwd(), 'android'), { recursive: true, force: true });
+console.log('Directorios dist/ y android/ eliminados si existían.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add Capacitor configuration and TypeScript settings to wrap the existing web app as a native Android project
- provide npm scripts to build the web assets, sync the Android project, and clean generated artifacts
- document the end-to-end steps required to generate an APK with Capacitor and Android Studio

## Testing
- node scripts/build.js

------
https://chatgpt.com/codex/tasks/task_e_68ded4c2b6c08327abf9d3aff0b4a3f4