### PR TITLE
Simplify Android Gradle plugin configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id("com.android.application")
+}
 
 android {
     namespace 'com.example.dirscrapping'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,1 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.2'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
+// Intentionally left blank; plugin and repository management handled via settings.gradle.

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -6,6 +6,9 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    plugins {
+        id("com.android.application") version "8.5.2"
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- remove redundant repository declarations from the top-level Gradle build file
- declare the Android Gradle Plugin version via the settings plugin management block
- switch the app module to the plugins DSL so it inherits the centrally managed version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df2785ee5c8327941dc479fe5fc1c8